### PR TITLE
Upgraded to new reactivesocket-java

### DIFF
--- a/src/main/java/io/reactivesocket/websocket/rxnetty/ReactiveSocketWebSocketClient.java
+++ b/src/main/java/io/reactivesocket/websocket/rxnetty/ReactiveSocketWebSocketClient.java
@@ -15,66 +15,98 @@
  */
 package io.reactivesocket.websocket.rxnetty;
 
+import static rx.RxReactiveStreams.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.reactivestreams.Publisher;
+
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.reactivesocket.DuplexConnection;
 import io.reactivesocket.Frame;
+import io.reactivesocket.Payload;
 import io.reactivesocket.ReactiveSocket;
 import io.reactivex.netty.protocol.http.ws.WebSocketConnection;
-import org.reactivestreams.Publisher;
 import rx.Observable;
 import rx.Single;
 
-import static rx.RxReactiveStreams.toObservable;
-import static rx.RxReactiveStreams.toPublisher;
-
 public class ReactiveSocketWebSocketClient {
 
-    private final ReactiveSocket reactiveSocket;
+	private final ReactiveSocket reactiveSocket;
+	private Publisher<Void> connect;
+	private final AtomicBoolean connected = new AtomicBoolean(false);
+	private final AtomicBoolean terminated = new AtomicBoolean(false);
 
-    private ReactiveSocketWebSocketClient(WebSocketConnection wsConn) {
-        this.reactiveSocket = ReactiveSocket.connect(
-            new DuplexConnection()
-            {
-                @Override
-                public Publisher<Frame> getInput()
-                {
-                    return toPublisher(wsConn.getInput().map(frame -> {
-                        return Frame.from(frame.content().nioBuffer());
-                    }));
-                }
+	private ReactiveSocketWebSocketClient(WebSocketConnection wsConn) {
+		this.reactiveSocket = ReactiveSocket.createRequestor();
+		connect = this.reactiveSocket.connect(
+				new DuplexConnection() {
+					@Override
+					public Publisher<Frame> getInput() {
+						return toPublisher(wsConn.getInput().map(frame -> {
+							return Frame.from(frame.content().nioBuffer());
+						}));
+					}
 
-                @Override
-                public Publisher<Void> write(Publisher<Frame> o)
-                {
-                    // had to use writeAndFlushOnEach instead of write for frames to get through
-                    // TODO determine if that's expected or not
-                    return toPublisher(wsConn.writeAndFlushOnEach(toObservable(o).map(frame -> {
-                        // return new BinaryWebSocketFrame(Unpooled.wrappedBuffer(m.getBytes()));
-                        return new TextWebSocketFrame(Unpooled.wrappedBuffer(frame.getByteBuffer()));
-                    })));
-                }
-            });
-    }
+					@Override
+					public Publisher<Void> write(Publisher<Frame> o) {
+						// had to use writeAndFlushOnEach instead of write for frames to get through
+						// TODO determine if that's expected or not
+						Publisher<Void> p = toPublisher(wsConn.writeAndFlushOnEach(toObservable(o)
+								.map(frame -> new BinaryWebSocketFrame(Unpooled.wrappedBuffer(frame.getByteBuffer())))
+						).doOnSubscribe(() -> System.out.println("DuplexConnection subscribe to Netty writeAndFlush " + System.currentTimeMillis()))
+								);
+						return p;
+					}
+				});
+	}
 
-    public static ReactiveSocketWebSocketClient create(WebSocketConnection ws) {
-        return new ReactiveSocketWebSocketClient(ws);
-    }
+	public static ReactiveSocketWebSocketClient create(WebSocketConnection ws) {
+		return new ReactiveSocketWebSocketClient(ws);
+	}
 
-    public Single<String> requestResponse(String request) {
-        return toObservable(reactiveSocket.requestResponse(request, null)).toSingle();
-    }
+	public Single<Payload> requestResponse(Payload request) {
+		assertConnection();
+		return toObservable(reactiveSocket.requestResponse(request)).toSingle();
+	}
 
-    public Observable<String> requestStream(String request) {
-        return toObservable(reactiveSocket.requestStream(request, null));
-    }
+	public Observable<Payload> requestStream(Payload request) {
+		assertConnection();
+		return toObservable(reactiveSocket.requestStream(request));
+	}
 
-    public Observable<String> requestSubscription(String topic) {
-        return toObservable(reactiveSocket.requestSubscription(topic, null));
-    }
+	public Observable<Payload> requestSubscription(Payload topic) {
+		assertConnection();
+		return toObservable(reactiveSocket.requestSubscription(topic));
+	}
 
-    public Single<Void> fireAndForget(String request) {
-        return toObservable(reactiveSocket.fireAndForget(request, null)).toSingle();
-    }
+	public Single<Void> fireAndForget(Payload request) {
+		assertConnection();
+		return toObservable(reactiveSocket.fireAndForget(request)).toSingle();
+	}
+
+	private void assertConnection() {
+		if (!connected.get()) {
+			throw new IllegalStateException("connect().subscribe() must occur first.");
+		}
+		if (terminated.get()) {
+			throw new IllegalStateException("connection is terminated");
+		}
+	}
+
+	/**
+	 * Connect the underlying channel to permit requests.
+	 * 
+	 * Start, monitor errors, and disconnect with the returned Single.
+	 * 
+	 * @return
+	 */
+	public Single<Void> connect() {
+		// TODO what should we do if somehow double subscribes?
+		return toObservable(connect)
+				.doOnSubscribe(() -> connected.set(true))
+				.doOnTerminate(() -> terminated.set(true)).toSingle();
+	}
 
 }

--- a/src/test/java/io/reactivesocket/websocket/rxnetty/ClientServerTest.java
+++ b/src/test/java/io/reactivesocket/websocket/rxnetty/ClientServerTest.java
@@ -15,6 +15,7 @@
  */
 package io.reactivesocket.websocket.rxnetty;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import io.netty.channel.ChannelOption;
@@ -22,6 +23,7 @@ import io.netty.handler.logging.LogLevel;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import static io.reactivesocket.websocket.rxnetty.TestUtil.*;
 
 import io.netty.buffer.ByteBuf;
 import io.reactivex.netty.protocol.http.client.HttpClient;
@@ -33,64 +35,79 @@ import rx.observers.TestSubscriber;
 
 public class ClientServerTest {
 
-    static Observable<ReactiveSocketWebSocketClient> client;
-    static HttpServer<ByteBuf, ByteBuf> server;
+	static ReactiveSocketWebSocketClient client;
+	static HttpServer<ByteBuf, ByteBuf> server;
 
-    @BeforeClass
-    public static void setup() {
-        ReactiveSocketWebSocketServer serverHandler = ReactiveSocketWebSocketServer.create(
-                requestResponse -> {
-                    return Single.just(requestResponse + " world");
-                } ,
-                requestStream -> {
-                    return Observable.just(requestStream, "world");
-                } , null, null);
+	@BeforeClass
+	public static void setup() {
+		ReactiveSocketWebSocketServer serverHandler = ReactiveSocketWebSocketServer.create(
+				requestResponsePayload -> {
+					String requestResponse = byteToString(requestResponsePayload.getData());
+					return Single.just(utf8EncodedPayloadData(requestResponse + " world"));
+				} ,
+				requestStreamPayload -> {
+					String requestStream = byteToString(requestStreamPayload.getData());
+					return Observable.just(requestStream, "world").map(n -> utf8EncodedPayloadData(n));
+				} , null, null);
 
-        server = HttpServer.newServer().clientChannelOption(ChannelOption.AUTO_READ, true).enableWireLogging(LogLevel.ERROR).start((req, resp) -> {
-            return resp.acceptWebSocketUpgrade(serverHandler::acceptWebsocket);
-        });
+		server = HttpServer.newServer()
+//				.clientChannelOption(ChannelOption.AUTO_READ, true)
+//				.enableWireLogging(LogLevel.ERROR)
+				.start((req, resp) -> {
+					return resp.acceptWebSocketUpgrade(serverHandler::acceptWebsocket);
+				});
 
-        client = HttpClient.newClient("localhost", server.getServerPort()).enableWireLogging(LogLevel.ERROR)
-                .createGet("/rs")
-                .requestWebSocketUpgrade()
-                .flatMap(WebSocketResponse::getWebSocketConnection)
-                .map(ReactiveSocketWebSocketClient::create);
-    }
+		client = HttpClient.newClient("localhost", server.getServerPort()).enableWireLogging(LogLevel.ERROR)
+				.createGet("/rs")
+				.requestWebSocketUpgrade()
+				.flatMap(WebSocketResponse::getWebSocketConnection)
+				.map(ReactiveSocketWebSocketClient::create)
+				.toBlocking().single();
 
-    @AfterClass
-    public static void tearDown() {
-        server.shutdown();
-    }
+		client.connect()
+				.subscribe(v -> {}, t -> t.printStackTrace());
+	}
 
-    @Test
-    public void testRequestResponse() {
-        TestSubscriber<String> ts = TestSubscriber.create();
-        client.flatMap(reactiveSocket -> {
-            return reactiveSocket.requestResponse("hello").toObservable();
-        }).subscribe(ts);
-        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertValue("hello world");
-    }
+	@AfterClass
+	public static void tearDown() {
+		server.shutdown();
+	}
 
-    @Test
-    public void testRequestResponseMultiple() {
-        TestSubscriber<String> ts = TestSubscriber.create();
-        client.flatMap(reactiveSocket -> {
-            return reactiveSocket.requestResponse("hello")
-                    .mergeWith(reactiveSocket.requestResponse("hi"));
-        }).subscribe(ts);
-        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertValues("hello world", "hi world");
-    }
+	@Test
+	public void testRequestResponse() {
+		TestSubscriber<String> ts = TestSubscriber.create();
+		client.requestResponse(utf8EncodedPayloadData("hello"))
+				.map(payload -> byteToString(payload.getData()))
+				.subscribe(ts);
+		ts.awaitTerminalEvent(1500, TimeUnit.MILLISECONDS);
+		ts.assertNoErrors();
+		ts.assertCompleted();
+		ts.assertValue("hello world");
+	}
 
-    @Test
-    public void testRequestStream() {
-        TestSubscriber<String> ts = TestSubscriber.create();
-        client.flatMap(reactiveSocket -> {
-            return reactiveSocket.requestStream("hello");
-        }).subscribe(ts);
-        ts.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
-        ts.assertValues("hello", "world");
-    }
+	@Test
+	public void testRequestResponseMultiple() {
+		TestSubscriber<String> ts = TestSubscriber.create();
+		client.requestResponse(utf8EncodedPayloadData("hello"))
+				.mergeWith(client.requestResponse(utf8EncodedPayloadData("hi")))
+				.map(payload -> byteToString(payload.getData()))
+				.subscribe(ts);
+		ts.awaitTerminalEvent(1500, TimeUnit.MILLISECONDS);
+		ts.assertNoErrors();
+		ts.assertCompleted();
+		ts.assertValues("hello world", "hi world");
+	}
+
+	@Test
+	public void testRequestStream() {
+		TestSubscriber<String> ts = TestSubscriber.create();
+		client.requestStream(utf8EncodedPayloadData("hello"))
+				.map(payload -> byteToString(payload.getData()))
+				.subscribe(ts);
+		ts.awaitTerminalEvent(1500, TimeUnit.MILLISECONDS);
+		ts.assertNoErrors();
+		ts.assertCompleted();
+		ts.assertValues("hello", "world");
+	}
 
 }

--- a/src/test/java/io/reactivesocket/websocket/rxnetty/ReactiveSocketWebSocketServerTest.java
+++ b/src/test/java/io/reactivesocket/websocket/rxnetty/ReactiveSocketWebSocketServerTest.java
@@ -18,6 +18,7 @@ package io.reactivesocket.websocket.rxnetty;
 import static rx.Observable.*;
 
 import org.junit.Test;
+import static io.reactivesocket.websocket.rxnetty.TestUtil.*;
 
 import io.netty.buffer.ByteBuf;
 import io.reactivesocket.websocket.rxnetty.ReactiveSocketWebSocketServer;
@@ -31,11 +32,13 @@ public class ReactiveSocketWebSocketServerTest {
     public void test() {
         // create protocol with handlers
         ReactiveSocketWebSocketServer handler = ReactiveSocketWebSocketServer.create(
-                requestResponse -> {
-                    return Single.just("hello" + requestResponse);
+        		requestResponsePayload -> {
+                	String requestResponse = byteToString(requestResponsePayload.getData()); 
+                    return Single.just(utf8EncodedPayloadData("hello" + requestResponse));
                 } ,
-                requestStream -> {
-                    return just("a_" + requestStream, "b_" + requestStream);
+        		requestStreamPayload -> {
+                	String requestStream = byteToString(requestStreamPayload.getData());
+                    return just("a_" + requestStream, "b_" + requestStream).map(n -> utf8EncodedPayloadData(n));
                 } , null, null);
 
         // start server with protocol

--- a/src/test/java/io/reactivesocket/websocket/rxnetty/TestUtil.java
+++ b/src/test/java/io/reactivesocket/websocket/rxnetty/TestUtil.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivesocket.websocket.rxnetty;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+import io.reactivesocket.Frame;
+import io.reactivesocket.FrameType;
+import io.reactivesocket.Payload;
+
+public class TestUtil
+{
+    public static Frame utf8EncodedFrame(final long streamId, final FrameType type, final String data)
+    {
+        return Frame.from(streamId, type, byteBufferFromUtf8String(data));
+    }
+
+    public static Payload utf8EncodedPayloadData(final String data)
+    {
+        return new PayloadImpl(data, null);
+    }
+    
+    public static Payload utf8EncodedPayload(final String data, final String metadata)
+    {
+        return new PayloadImpl(data, metadata);
+    }
+
+    public static String byteToString(final ByteBuffer byteBuffer)
+    {
+        final byte[] bytes = new byte[byteBuffer.capacity()];
+        byteBuffer.get(bytes);
+        return new String(bytes, Charset.forName("UTF-8"));
+    }
+
+    public static ByteBuffer byteBufferFromUtf8String(final String data)
+    {
+        final byte[] bytes = data.getBytes(Charset.forName("UTF-8"));
+        return ByteBuffer.wrap(bytes);
+    }
+
+    private static class PayloadImpl implements Payload // some JDK shoutout
+    {
+        private ByteBuffer data;
+        private ByteBuffer metadata;
+
+        public PayloadImpl(final String data, final String metadata)
+        {
+            if (null == data)
+            {
+                this.data = ByteBuffer.allocate(0);
+            }
+            else
+            {
+                this.data = byteBufferFromUtf8String(data);
+            }
+
+            if (null == metadata)
+            {
+                this.metadata = ByteBuffer.allocate(0);
+            }
+            else
+            {
+                this.metadata = byteBufferFromUtf8String(metadata);
+            }
+        }
+
+        public boolean equals(Object obj)
+        {
+            final Payload rhs = (Payload)obj;
+
+            return (TestUtil.byteToString(data).equals(TestUtil.byteToString(rhs.getData()))) &&
+                (TestUtil.byteToString(metadata).equals(TestUtil.byteToString(rhs.getMetadata())));
+        }
+
+        public ByteBuffer getData()
+        {
+            return data;
+        }
+
+        public ByteBuffer getMetadata()
+        {
+            return metadata;
+        }
+    }
+
+}


### PR DESCRIPTION
- uses Binary
- ***but*** there is a ~600ms slowdown happening on client requests that I've traced to RxNetty subscribing to the writer Subject I give it. I haven't yet figured out what's going on. I have left debug printlns in place, and use of ReplaySubject to deal with the race condition that I haven't yet figured out related to this delay.
- so (a) need to solve the delay and (b) need to figure out what to wait on before submitting the REQUEST_FRAME so I don't need a ReplaySubject